### PR TITLE
Bump shipshape / Small fixes on tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/rh-messaging/shipshape v0.3.3
+	github.com/rh-messaging/shipshape v0.3.4
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -82,6 +82,6 @@ require (
 // For local override of dependencies, use following:
 // replace github.com/rh-messaging/activemq-artemis-operator v0.0.0+incompatible => ../../../github.com/rh-messaging/activemq-artemis-operator
 
-//replace github.com/rh-messaging/shipshape v0.2.7 => ../../../github.com/rh-messaging/shipshape
+//replace github.com/rh-messaging/shipshape v0.3.4 => ../../../github.com/rh-messaging/shipshape
 
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/rh-messaging/shipshape v0.3.4
+	github.com/rh-messaging/shipshape v0.3.5
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -82,6 +82,6 @@ require (
 // For local override of dependencies, use following:
 // replace github.com/rh-messaging/activemq-artemis-operator v0.0.0+incompatible => ../../../github.com/rh-messaging/activemq-artemis-operator
 
-//replace github.com/rh-messaging/shipshape v0.3.4 => ../../../github.com/rh-messaging/shipshape
+//replace github.com/rh-messaging/shipshape v0.3.5 => ../../../github.com/rh-messaging/shipshape
 
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -618,6 +618,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rh-messaging/shipshape v0.3.3 h1:oZgeFY54mKzID0JvqxrEQmxnx01fKTvGqk6Q+/m6b28=
 github.com/rh-messaging/shipshape v0.3.3/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
+github.com/rh-messaging/shipshape v0.3.4 h1:iJd+aaxvRO4Zijr6KzAtDcvvOkGRQyBVZhQD0MKNubQ=
+github.com/rh-messaging/shipshape v0.3.4/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/go.sum
+++ b/go.sum
@@ -620,6 +620,8 @@ github.com/rh-messaging/shipshape v0.3.3 h1:oZgeFY54mKzID0JvqxrEQmxnx01fKTvGqk6Q
 github.com/rh-messaging/shipshape v0.3.3/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
 github.com/rh-messaging/shipshape v0.3.4 h1:iJd+aaxvRO4Zijr6KzAtDcvvOkGRQyBVZhQD0MKNubQ=
 github.com/rh-messaging/shipshape v0.3.4/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
+github.com/rh-messaging/shipshape v0.3.5 h1:gOKn6pegJKqmQCXZuDWkEAhf5MfxgHmG/rJYg9nCpzA=
+github.com/rh-messaging/shipshape v0.3.5/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/bdw/broker_deployment_wrapper_helpers.go
+++ b/pkg/bdw/broker_deployment_wrapper_helpers.go
@@ -65,7 +65,9 @@ func (bdw *BrokerDeploymentWrapper) GetFile(podname, containername, filename str
 			TTY:       false,
 		}, scheme.ParameterCodec)
 
-	restconfig.TLSClientConfig.Insecure = true
+	if len(restconfig.CAData) == 0 {
+		restconfig.TLSClientConfig.Insecure = true
+	}
 	exec, err := remotecommand.NewSPDYExecutor(&restconfig, "POST", req.URL())
 	if err != nil {
 		return "", err
@@ -137,7 +139,7 @@ func (bdw *BrokerDeploymentWrapper) SetEnvVariable(name, value string) {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
-//This expects to be ran on openshift.
+// This expects to be ran on openshift.
 func (bdw *BrokerDeploymentWrapper) GetExternalUrls(filter string, podNumber int) ([]string, error) {
 	var result []string
 	routes, _ := bdw.ctx1.Clients.OcpClient.RoutesClient.RouteV1().Routes(bdw.ctx1.Namespace).List(context.TODO(), v1.ListOptions{})
@@ -162,7 +164,7 @@ func contains(arr []string, str string) bool {
 	return false
 }
 
-//We always configure Artemis as if it is latest API version
+// We always configure Artemis as if it is latest API version
 func (bdw *BrokerDeploymentWrapper) ConfigureBroker(artemis *brokerbeta.ActiveMQArtemis, acceptorType AcceptorType) *brokerbeta.ActiveMQArtemis {
 	artemis.Spec.DeploymentPlan.Size = int32(bdw.deploymentSize)
 	if acceptorType != NoChangeAcceptor {

--- a/test/deployment/resources/resource_request_test.go
+++ b/test/deployment/resources/resource_request_test.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("ResourceRequestsTests", func() {
 		gomega.Expect(expectedMemRequest).To(gomega.Equal(actualMemRequest.String()), "Expected Memory limit: %s, real: %s", expectedMemRequest, actualMemRequest.String())
 	})
 
-	ginkgo.It("Memory Request update check", func() {
+	ginkgo.PIt("Memory Request update check", func() {
 		expectedMemRequest := "512M"
 		brokerDeployer.WithMemRequest(expectedMemRequest)
 		deployBroker(brokerDeployer)

--- a/test/misc/statistics/statistics_test.go
+++ b/test/misc/statistics/statistics_test.go
@@ -2,13 +2,14 @@ package statistics
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/artemiscloud/activemq-artemis-operator-test-suite/pkg/bdw"
 	"github.com/artemiscloud/activemq-artemis-operator-test-suite/test"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/rh-messaging/shipshape/pkg/framework"
-	"io/ioutil"
-	"net/http"
 )
 
 var _ = ginkgo.Describe("StatisticsTest", func() {
@@ -90,7 +91,7 @@ var _ = ginkgo.Describe("StatisticsTest", func() {
 
 			}) */
 
-	ginkgo.It("StatisticsWithConsoleTestChangeSetup", func() {
+	ginkgo.PIt("StatisticsWithConsoleTestChangeSetup", func() {
 		brokerDeployer.WithConsoleExposure(false)
 		err := brokerDeployer.DeployBrokers(1)
 		if err != nil {

--- a/test/smoke/basic/basic_deployment_test.go
+++ b/test/smoke/basic/basic_deployment_test.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("DeploymentBasicTests", func() {
 		initName := ""
 		if imageArch == "" {
 			imageName = fmt.Sprintf("%s_%s", decideImageName(), imagever)
-			initName = fmt.Sprintf("RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init%s", imagever)
+			initName = fmt.Sprintf("RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_%s", imagever)
 		} else {
 			imageName = fmt.Sprintf("%s_%s_%s", decideImageName(), imagever, imageArch)
 			initName = fmt.Sprintf("RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_%s%s", imagever, imageArch)

--- a/test/smoke/basic/basic_deployment_test.go
+++ b/test/smoke/basic/basic_deployment_test.go
@@ -83,6 +83,7 @@ var _ = ginkgo.Describe("DeploymentBasicTests", func() {
 		initjavaopts := getEnvVarValue("JAVA_OPTS", ss.Spec.Template.Spec.InitContainers[0].Env)
 		filename := strings.Split(initjavaopts, "=")[1]
 		propertiesfile, err := brokerDeployer.GetFile("basic-ss-0", "basic-container", filename, sw.Framework.GetConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error reading properties file")
 		gomega.Expect(propertiesfile).To(gomega.ContainSubstring("abyrvalg=bluepinspio"), "properties file doesn't contain the expected string")
 		//		propertiesfile, err := brokerDeployer.GetFile("basic-ss-0", "basic-container", "/home/jboss/amq-broker/etc/"
 		// TODO: Properties broken? Currently it only verifies existing issue of wrong array type being supplied to CR


### PR DESCRIPTION
This MR contains:
  - the shipshape version bump which is required to run the test suite on OCP 4.12+
  - Fix on Deploy older broker version test which had a typo on init container image
  - Disable of StatisticsWithConsoleTestChangeSetup as it is not working due the broker do not restarts afte environment variable change
  - Disable Memory Request update check as it is not working due the broker do not restarts after memory request change
  - Fix drainer verification on message migration tests
