### PR TITLE
Fixes for ppc64le and s390x image search

### DIFF
--- a/test/smoke/basic/basic_deployment_test.go
+++ b/test/smoke/basic/basic_deployment_test.go
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe("DeploymentBasicTests", func() {
 			initName = fmt.Sprintf("RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_%s", imagever)
 		} else {
 			imageName = fmt.Sprintf("%s_%s_%s", decideImageName(), imagever, imageArch)
-			initName = fmt.Sprintf("RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_%s%s", imagever, imageArch)
+			initName = fmt.Sprintf("RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_%s_%s", imagever, imageArch)
 		}
 		gomega.Expect(ss.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal(getEnvVarValue(imageName, images)), "wrong broker image used in actual SS")
 		gomega.Expect(ss.Spec.Template.Spec.InitContainers[0].Image).To(gomega.Equal(getEnvVarValue(initName, images)), "wrong broker image used in actual SS")

--- a/test/smoke/basic/basic_update_test.go
+++ b/test/smoke/basic/basic_update_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	PPC  = "_ppc64le"
-	IBMZ = "_s390x"
+	PPC  = "ppc64le"
+	IBMZ = "s390x"
 )
 
 func determineInit() string {
@@ -26,13 +26,14 @@ func determineInit() string {
 	images := test.GetImages()
 	for _, item := range images {
 		if strings.HasPrefix(item.Name, initName) && strings.HasSuffix(item.Name, imageArch) {
-			if imageArch == "" {
-				if !strings.HasSuffix(item.Name, PPC) && !strings.HasSuffix(item.Name, IBMZ) {
+			if imageArch != "" {
+				if strings.HasSuffix(item.Name, PPC) || strings.HasSuffix(item.Name, IBMZ) {
 					CustomInit = item.Value
 					break
 				}
 			} else {
 				CustomInit = item.Value
+				break
 			}
 		}
 	}
@@ -46,8 +47,8 @@ func determineImage() string {
 	CustomImage := ""
 	for _, item := range images {
 		if strings.HasPrefix(item.Name, imageName) && strings.HasSuffix(item.Name, imageArch) {
-			if imageArch == "" { // Also check lack of other architectures..
-				if !strings.HasSuffix(item.Name, PPC) && !strings.HasSuffix(item.Name, IBMZ) {
+			if imageArch != "" { // Also check lack of other architectures..
+				if strings.HasSuffix(item.Name, PPC) || strings.HasSuffix(item.Name, IBMZ) {
 					CustomImage = item.Value
 					break
 				}


### PR DESCRIPTION
These changes fix the following test:

Basic Suite.DeploymentBasicTests Deploy older broker version
Basic Suite.DeploymentUpdateTests CustomImageOverrideTest
Basic Suite.DeploymentBasicTests Deploy multiple broker sets with different configuration