### PR TITLE
bump shipshape to version 0.3.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/rh-messaging/shipshape v0.3.5
+	github.com/rh-messaging/shipshape v0.3.6
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -82,6 +82,6 @@ require (
 // For local override of dependencies, use following:
 // replace github.com/rh-messaging/activemq-artemis-operator v0.0.0+incompatible => ../../../github.com/rh-messaging/activemq-artemis-operator
 
-//replace github.com/rh-messaging/shipshape v0.3.5 => ../../../github.com/rh-messaging/shipshape
+//replace github.com/rh-messaging/shipshape v0.3.6 => ../../../github.com/rh-messaging/shipshape
 
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -622,6 +622,8 @@ github.com/rh-messaging/shipshape v0.3.4 h1:iJd+aaxvRO4Zijr6KzAtDcvvOkGRQyBVZhQD
 github.com/rh-messaging/shipshape v0.3.4/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
 github.com/rh-messaging/shipshape v0.3.5 h1:gOKn6pegJKqmQCXZuDWkEAhf5MfxgHmG/rJYg9nCpzA=
 github.com/rh-messaging/shipshape v0.3.5/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
+github.com/rh-messaging/shipshape v0.3.6 h1:bXG03wtLcSujkVIcK1JCqmtRxozGWq8rlcdIQjKUPZk=
+github.com/rh-messaging/shipshape v0.3.6/go.mod h1:EdVreCf4Ib+t1HzT/oj+m8T5EPGcpmRMYAdJLpRvqhA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=


### PR DESCRIPTION
Bum to new shipshape version which fixes a issue on OCP 4.10
Ref: https://github.com/rh-messaging/shipshape/pull/75