### PR TITLE
don't parse resource version

### DIFF
--- a/pkg/bdw/broker_deployment_wrapper_deployers.go
+++ b/pkg/bdw/broker_deployment_wrapper_deployers.go
@@ -95,15 +95,11 @@ func (bdw *BrokerDeploymentWrapper) DeployBrokers(count int) error {
 }
 
 func (bdw *BrokerDeploymentWrapper) Update() error {
-	resourceVersion := int64(0)
 	var err error
 	// getting created artemis custom resource to overwrite the resourceVersion and params.
 	artemisCreated, err := bdw.brokerClient.BrokerV1beta1().ActiveMQArtemises(bdw.ctx1.Namespace).Get(bdw.name, v1.GetOptions{})
 	gomega.Expect(err).To(gomega.BeNil())
 	originalSize := artemisCreated.Spec.DeploymentPlan.Size
-	resourceVersion, err = strconv.ParseInt(string(artemisCreated.ObjectMeta.ResourceVersion), 10, 64)
-	gomega.Expect(err).To(gomega.BeNil())
-	artemisCreated.ObjectMeta.ResourceVersion = strconv.FormatInt(int64(resourceVersion), 10)
 
 	bdw.ConfigureBroker(artemisCreated, NoChangeAcceptor)
 


### PR DESCRIPTION
Parsing the resourceVersion as an integer is strictly prohibited by the Kubernetes API [1]. During a review of code that would be affected by non-numerical resourceVersions, I came upon this code. As the parsed data is not used for anything, it looks like it's possible to simply remove this parsing logic.

[1] https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>